### PR TITLE
Add typing to ``filepath`` and change tests

### DIFF
--- a/pylint/config/option_manager_mixin.py
+++ b/pylint/config/option_manager_mixin.py
@@ -10,6 +10,7 @@ import functools
 import optparse  # pylint: disable=deprecated-module
 import os
 import sys
+from typing import List
 
 import toml
 
@@ -326,7 +327,7 @@ class OptionsManagerMixIn:
             provider = self._all_options[opt]
             provider.set_option(opt, opt_value)
 
-    def load_command_line_configuration(self, args=None):
+    def load_command_line_configuration(self, args=None) -> List[str]:
         """Override configuration according to command line parameters
 
         return additional arguments

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -1,8 +1,27 @@
 import os
 import sys
-from typing import List, Pattern, Tuple
+from typing import List, Pattern, Tuple, Union
 
 from astroid import modutils
+
+if sys.version_info >= (3, 8):
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal, TypedDict
+
+
+class MODULE_DESCRIPTION_DICT(TypedDict):
+    path: str
+    name: str
+    isarg: bool
+    basepath: str
+    basename: str
+
+
+class ERROR_DESCRIPTION_DICT(TypedDict):
+    key: Literal["fatal"]
+    mod: str
+    ex: Union[ImportError, SyntaxError]
 
 
 def _modpath_from_file(filename, is_namespace, path=None):
@@ -42,12 +61,12 @@ def expand_modules(
     ignore_list: List[str],
     ignore_list_re: List[Pattern],
     ignore_list_paths_re: List[Pattern],
-) -> Tuple[List[dict], List[dict]]:
+) -> Tuple[List[MODULE_DESCRIPTION_DICT], List[ERROR_DESCRIPTION_DICT]]:
     """take a list of files/modules/packages and return the list of tuple
     (file, module name) which have to be actually checked
     """
-    result = []
-    errors = []
+    result: List[MODULE_DESCRIPTION_DICT] = []
+    errors: List[ERROR_DESCRIPTION_DICT] = []
     path = sys.path.copy()
 
     for something in files_or_modules:

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -5,8 +5,7 @@ import contextlib
 import sys
 import traceback
 from datetime import datetime
-from pathlib import Path, PosixPath
-from typing import Union
+from pathlib import Path
 
 from pylint.config import PYLINT_HOME
 from pylint.lint.expand_modules import get_python_path
@@ -16,9 +15,7 @@ class ArgumentPreprocessingError(Exception):
     """Raised if an error occurs during argument preprocessing."""
 
 
-def prepare_crash_report(
-    ex: Exception, filepath: PosixPath, crash_file_path: Union[Path, str]
-) -> Path:
+def prepare_crash_report(ex: Exception, filepath: str, crash_file_path: str) -> Path:
     issue_template_path = (
         Path(PYLINT_HOME) / datetime.now().strftime(str(crash_file_path))
     ).resolve()
@@ -63,7 +60,7 @@ pylint crashed with a ``{ex.__class__.__name__}`` and with the following stacktr
     return issue_template_path
 
 
-def get_fatal_error_message(filepath: str, issue_template_path: str) -> str:
+def get_fatal_error_message(filepath: str, issue_template_path: Path) -> str:
     return (
         f"Fatal error while checking '{filepath}'. "
         f"Please open an issue in our bug tracker so we address this. "

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-from typing import List
+from typing import List, Optional
 
 from pylint.message import Message
 
@@ -62,7 +62,7 @@ class BaseReporter:
 
     # Event callbacks
 
-    def on_set_current_module(self, module, filepath):
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         """Hook called when a module starts to be analysed."""
 
     def on_close(self, stats, previous_stats):

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -3,7 +3,7 @@
 
 
 import os
-from typing import IO, Any, AnyStr, Callable, List, Mapping, Optional, Union
+from typing import IO, Any, AnyStr, Callable, List, Mapping, Optional
 
 from pylint.interfaces import IReporter
 from pylint.message import Message
@@ -11,7 +11,6 @@ from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.ureports.nodes import BaseLayout
 
 AnyFile = IO[AnyStr]
-AnyPath = Union[str, bytes, os.PathLike]
 PyLinter = Any
 
 
@@ -88,7 +87,7 @@ class MultiReporter:
         for rep in self._sub_reporters:
             rep.display_messages(layout)
 
-    def on_set_current_module(self, module: str, filepath: Optional[AnyPath]) -> None:
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         """hook called when a module starts to be analysed"""
         for rep in self._sub_reporters:
             rep.on_set_current_module(module, filepath)

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -25,6 +25,7 @@
 import os
 import sys
 import warnings
+from typing import Optional
 
 from pylint import utils
 from pylint.interfaces import IReporter
@@ -136,7 +137,7 @@ class TextReporter(BaseReporter):
         self._modules = set()
         self._template = self.line_format
 
-    def on_set_current_module(self, module, filepath):
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         self._template = str(self.linter.config.msg_template or self._template)
 
     def write_message(self, msg):

--- a/pylint/testutils/reporter_for_tests.py
+++ b/pylint/testutils/reporter_for_tests.py
@@ -3,7 +3,7 @@
 
 from io import StringIO
 from os import getcwd, linesep, sep
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pylint import interfaces
 from pylint.message import Message
@@ -51,7 +51,7 @@ class GenericTestReporter(BaseReporter):
         return result
 
     # pylint: disable=unused-argument
-    def on_set_current_module(self, module, filepath):
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         pass
 
     # pylint: enable=unused-argument
@@ -63,14 +63,14 @@ class GenericTestReporter(BaseReporter):
 
 
 class MinimalTestReporter(BaseReporter):
-    def on_set_current_module(self, module, filepath):
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         self.messages = []
 
     _display = None
 
 
 class FunctionalTestReporter(BaseReporter):
-    def on_set_current_module(self, module, filepath):
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         self.messages = []
 
     def display_reports(self, layout):

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -368,7 +368,7 @@ class TestMissingSubmodule(CheckerTestCase):
 
         sys.path.insert(0, REGR_DATA_DIR)
         try:
-            linter.check(os.path.join(REGR_DATA_DIR, "package_all"))
+            linter.check([os.path.join(REGR_DATA_DIR, "package_all")])
             got = linter.reporter.finalize().strip()
             assert got == "E:  3: Undefined variable name 'missing' in __all__"
         finally:

--- a/tests/extensions/test_broad_try_clause.py
+++ b/tests/extensions/test_broad_try_clause.py
@@ -13,6 +13,7 @@
 """Tests for the pylint checker in :mod:`pylint.extensions.broad_try_clause`"""
 import unittest
 from os import path as osp
+from typing import Optional
 
 from pylint import checkers
 from pylint.extensions.broad_try_clause import BroadTryClauseChecker
@@ -21,7 +22,7 @@ from pylint.reporters import BaseReporter
 
 
 class BroadTryClauseTestReporter(BaseReporter):
-    def on_set_current_module(self, module: str, filepath: str) -> None:
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         self.messages = []
 
     def _display(self, layout):

--- a/tests/extensions/test_comparetozero.py
+++ b/tests/extensions/test_comparetozero.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+from typing import Optional
 
 from pylint import checkers
 from pylint.extensions.comparetozero import CompareToZeroChecker
@@ -22,7 +23,7 @@ from pylint.reporters import BaseReporter
 
 
 class CompareToZeroTestReporter(BaseReporter):
-    def on_set_current_module(self, module: str, filepath: str) -> None:
+    def on_set_current_module(self, module: str, filepath: Optional[str]) -> None:
         self.messages = []
 
     def _display(self, layout):

--- a/tests/lint/test_utils.py
+++ b/tests/lint/test_utils.py
@@ -1,4 +1,4 @@
-from pathlib import PosixPath
+from pathlib import Path, PosixPath
 
 from pylint.lint.utils import get_fatal_error_message, prepare_crash_report
 
@@ -13,7 +13,7 @@ def test_prepare_crash_report(tmp_path: PosixPath) -> None:
         raise Exception(exception_content)
     except Exception as ex:  # pylint: disable=broad-except
         template_path = prepare_crash_report(
-            ex, python_file, tmp_path / "pylint-crash-%Y.txt"
+            ex, str(python_file), str(tmp_path / "pylint-crash-%Y.txt")
         )
     assert str(tmp_path) in str(template_path)
     with open(template_path, encoding="utf8") as f:
@@ -27,7 +27,7 @@ def test_prepare_crash_report(tmp_path: PosixPath) -> None:
 def test_get_fatal_error_message() -> None:
     python_path = "mypath.py"
     crash_path = "crash.txt"
-    msg = get_fatal_error_message(python_path, crash_path)
+    msg = get_fatal_error_message(python_path, Path(crash_path))
     assert python_path in msg
     assert crash_path in msg
     assert "open an issue" in msg

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -269,7 +269,7 @@ def test_pylint_visit_method_taken_in_account(linter: PyLinter) -> None:
     linter.open()
     out = StringIO()
     linter.set_reporter(text.TextReporter(out))
-    linter.check("abc")
+    linter.check(["abc"])
 
 
 def test_enable_message(init_linter: PyLinter) -> None:
@@ -573,7 +573,7 @@ def test_init_hooks_called_before_load_plugins() -> None:
 
 def test_analyze_explicit_script(linter: PyLinter) -> None:
     linter.set_reporter(testutils.GenericTestReporter())
-    linter.check(os.path.join(DATA_DIR, "ascript"))
+    linter.check([os.path.join(DATA_DIR, "ascript")])
     assert ["C:  2: Line too long (175/100)"] == linter.reporter.messages
 
 
@@ -826,15 +826,15 @@ def test_filename_with__init__(init_linter: PyLinter) -> None:
 def test_by_module_statement_value(init_linter: PyLinter) -> None:
     """Test "statement" for each module analized of computed correctly."""
     linter = init_linter
-    linter.check(os.path.join(os.path.dirname(__file__), "data"))
+    linter.check([os.path.join(os.path.dirname(__file__), "data")])
 
     for module, module_stats in linter.stats["by_module"].items():
 
         linter2 = init_linter
         if module == "data":
-            linter2.check(os.path.join(os.path.dirname(__file__), "data/__init__.py"))
+            linter2.check([os.path.join(os.path.dirname(__file__), "data/__init__.py")])
         else:
-            linter2.check(os.path.join(os.path.dirname(__file__), module))
+            linter2.check([os.path.join(os.path.dirname(__file__), module)])
 
         # Check that the by_module "statement" is equal to the global "statement"
         # computed for that module

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -177,7 +177,7 @@ class TestCheckParallelFramework:
     def test_worker_check_single_file_uninitialised(self) -> None:
         pylint.lint.parallel._worker_linter = None
         with pytest.raises(  # Objects that do not match the linter interface will fail
-            AttributeError, match="'NoneType' object has no attribute 'open'"
+            Exception, match="Worker linter not yet initialised"
         ):
             worker_check_single_file(_gen_file_data())
 
@@ -289,7 +289,9 @@ class TestCheckParallel:
 
         # Invoke the lint process in a multiprocess way, although we only specify one
         # job.
-        check_parallel(linter, jobs=1, files=single_file_container, arguments=None)
+        check_parallel(
+            linter, jobs=1, files=iter(single_file_container), arguments=None
+        )
         assert len(linter.get_checkers()) == 2, (
             "We should only have the 'master' and 'sequential-checker' "
             "checkers registered"
@@ -318,7 +320,7 @@ class TestCheckParallel:
 
         # now run the regular mode of checking files and check that, in this proc, we
         # collect the right data
-        filepath = single_file_container[0][1]  # get the filepath element
+        filepath = [single_file_container[0][1]]  # get the filepath element
         linter.check(filepath)
         assert {
             "by_module": {
@@ -356,7 +358,9 @@ class TestCheckParallel:
 
         # Invoke the lint process in a multiprocess way, although we only specify one
         # job.
-        check_parallel(linter, jobs=1, files=single_file_container, arguments=None)
+        check_parallel(
+            linter, jobs=1, files=iter(single_file_container), arguments=None
+        )
 
         assert {
             "by_module": {

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -106,7 +106,7 @@ def test_checker_dep_graphs(linter: PyLinter) -> None:
     linter.global_set_option("int-import-graph", "int_import.dot")
     # ignore this file causing spurious MemoryError w/ some python version (>=2.3?)
     linter.global_set_option("ignore", ("func_unknown_encoding.py",))
-    linter.check("input")
+    linter.check(["input"])
     linter.generate_reports()
     assert exists("import.dot")
     assert exists("ext_import.dot")

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -61,15 +61,15 @@ def Equals(expected):
 @pytest.mark.parametrize(
     "file_name, check",
     [
-        ("package.__init__", Equals("")),
-        ("precedence_test", Equals("")),
-        ("import_package_subpackage_module", Equals("")),
-        ("pylint.checkers.__init__", lambda x: "__path__" not in x),
-        (join(REGR_DATA, "classdoc_usage.py"), Equals("")),
-        (join(REGR_DATA, "module_global.py"), Equals("")),
-        (join(REGR_DATA, "decimal_inference.py"), Equals("")),
-        (join(REGR_DATA, "absimp", "string.py"), Equals("")),
-        (join(REGR_DATA, "bad_package"), lambda x: "Unused import missing" in x),
+        (["package.__init__"], Equals("")),
+        (["precedence_test"], Equals("")),
+        (["import_package_subpackage_module"], Equals("")),
+        (["pylint.checkers.__init__"], lambda x: "__path__" not in x),
+        ([join(REGR_DATA, "classdoc_usage.py")], Equals("")),
+        ([join(REGR_DATA, "module_global.py")], Equals("")),
+        ([join(REGR_DATA, "decimal_inference.py")], Equals("")),
+        ([join(REGR_DATA, "absimp", "string.py")], Equals("")),
+        ([join(REGR_DATA, "bad_package")], lambda x: "Unused import missing" in x),
     ],
 )
 def test_package(finalize_linter, file_name, check):
@@ -94,7 +94,7 @@ def test_crash(finalize_linter, file_name):
     "fname", [x for x in os.listdir(REGR_DATA) if x.endswith("_crash.py")]
 )
 def test_descriptor_crash(fname: str, finalize_linter: PyLinter) -> None:
-    finalize_linter.check(join(REGR_DATA, fname))
+    finalize_linter.check([join(REGR_DATA, fname)])
     finalize_linter.reporter.finalize().strip()
 
 
@@ -109,13 +109,13 @@ def modify_path() -> Iterator:
 
 @pytest.mark.usefixtures("modify_path")
 def test_check_package___init__(finalize_linter: PyLinter) -> None:
-    filename = "package.__init__"
+    filename = ["package.__init__"]
     finalize_linter.check(filename)
     checked = list(finalize_linter.stats["by_module"].keys())
-    assert checked == [filename]
+    assert checked == filename
 
     os.chdir(join(REGR_DATA, "package"))
-    finalize_linter.check("__init__")
+    finalize_linter.check(["__init__"])
     checked = list(finalize_linter.stats["by_module"].keys())
     assert checked == ["__init__"]
 


### PR DESCRIPTION
This PR shows how changes to the tests do pass the test suite.

The change consist of:
- Making sure all file paths are a `list`
- Making sure that `test_worker_check_single_file_uninitialised` catches the new explicitly defined exception
- Making sure that `get_fatal_error_message` always gets a `Path` as second argument
- Making sure that `check_parallel` always gets an `Iterable`